### PR TITLE
Graphite metrics reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ test-deps:
 
 build-deps:
 	# TODO (boldfield) :: Generalize this
+	go get github.com/marpaia/graphite-golang
 	go get github.com/codegangsta/cli
 	go get github.com/ryanuber/columnize
 	go get code.google.com/p/gcfg

--- a/lib/mesos.go
+++ b/lib/mesos.go
@@ -53,9 +53,15 @@ func (m *Mesos) Framework(framework string) FrameworkMap {
 	return m.Cluster.GetFramework(framework)
 }
 
-func (m *Mesos) LoadSlave(host string, c *mesos.Client) (*MesosSlave, error) {
+func (m *Mesos) LoadSlaveState(host string, c *mesos.Client) (*MesosSlave, error) {
 	slave := &mesos.Slave{HostName: host}
 	err := slave.LoadState(c)
+	return &MesosSlave{Slave: slave}, err
+}
+
+func (m *Mesos) LoadSlaveStats(host string, c *mesos.Client) (*MesosSlave, error) {
+	slave := &mesos.Slave{HostName: host}
+	err := slave.LoadStats(c)
 	return &MesosSlave{Slave: slave}, err
 }
 

--- a/notadash-mon/allocation.go
+++ b/notadash-mon/allocation.go
@@ -20,7 +20,6 @@ func runShowAllocation(ctx *cli.Context) int {
 	return 0
 }
 
-
 func printAllocations(mesos *lib.Mesos) int {
 	output := make([]string, 1)
 	output[0] = "Hostnamme | Cpu % | Cpu Ratio | Mem % | Mem Ratio | Disk % | Disk Ratio"
@@ -30,13 +29,13 @@ func printAllocations(mesos *lib.Mesos) int {
 		ln := fmt.Sprintf(
 			"%s | %.0f | %.1f/%d | %.0f | %d/%d | %.0f| %d/%d",
 			s.HostName,
-			ss.CpusPercent * 100,
+			ss.CpusPercent*100,
 			ss.CpusUsed,
 			ss.CpusTotal,
-			ss.MemPercent * 100,
+			ss.MemPercent*100,
 			ss.MemUsed,
 			ss.MemTotal,
-			ss.DiskPercent * 100,
+			ss.DiskPercent*100,
 			ss.DiskUsed,
 			ss.DiskTotal,
 		)

--- a/notadash-mon/allocation.go
+++ b/notadash-mon/allocation.go
@@ -16,21 +16,27 @@ func runShowAllocation(ctx *cli.Context) int {
 	mesosClient := mesos.Client()
 	mesos.LoadCluster(mesosClient)
 
+	printAllocations(mesos)
+	return 0
+}
+
+
+func printAllocations(mesos *lib.Mesos) int {
 	output := make([]string, 1)
 	output[0] = "Hostnamme | Cpu % | Cpu Ratio | Mem % | Mem Ratio | Disk % | Disk Ratio"
 
 	for _, s := range mesos.Cluster.Slaves {
 		ss := s.Stats
 		ln := fmt.Sprintf(
-			"%s | %.2f | %.1f/%d | %.2f | %d/%d | %.2f| %d/%d",
+			"%s | %.0f | %.1f/%d | %.0f | %d/%d | %.0f| %d/%d",
 			s.HostName,
-			ss.CpusPercent,
+			ss.CpusPercent * 100,
 			ss.CpusUsed,
 			ss.CpusTotal,
-			ss.MemPercent,
+			ss.MemPercent * 100,
 			ss.MemUsed,
 			ss.MemTotal,
-			ss.DiskPercent,
+			ss.DiskPercent * 100,
 			ss.DiskUsed,
 			ss.DiskTotal,
 		)

--- a/notadash-mon/app.go
+++ b/notadash-mon/app.go
@@ -11,7 +11,6 @@ var VERSION = "0.1.0-beta"
 type boolmap map[string]bool
 
 var rsaRequired = []string{
-	"mesos-host",
 	"graphite-host",
 	"graphite-port",
 }
@@ -82,8 +81,8 @@ func buildApp() *cli.App {
 
 	app.Commands = []cli.Command{
 		{
-			Name: "report-allocation",
-			Usage: "send currently allocated resources to graphite",
+			Name:   "report-allocation",
+			Usage:  "send currently allocated resources to graphite",
 			Action: reportSlaveAllocation,
 		},
 		{

--- a/notadash-mon/app.go
+++ b/notadash-mon/app.go
@@ -43,6 +43,11 @@ func buildApp() *cli.App {
 			Usage: "Show more output",
 		},
 		cli.StringFlag{
+			Name:  "hostname",
+			Usage: "Hostname to use when reporting slave allocation",
+			Value: "localhost",
+		},
+		cli.StringFlag{
 			Name:   "graphite-host",
 			Usage:  "URL to use for Graphite metrics reporting.",
 			EnvVar: "NOTADASH_GRAPHITE_URL",
@@ -51,6 +56,7 @@ func buildApp() *cli.App {
 			Name:   "graphite-port",
 			Usage:  "Port to use for Graphite metrics reporting.",
 			EnvVar: "NOTADASH_GRAPHITE_PORT",
+			Value:  2003,
 		},
 		cli.StringFlag{
 			Name:   "marathon-host",
@@ -107,7 +113,7 @@ func buildApp() *cli.App {
 }
 
 func reportSlaveAllocation(ctx *cli.Context) {
-	if missing, err := validateContext(ctx, saRequired); err != nil {
+	if missing, err := validateContext(ctx, rsaRequired); err != nil {
 		fmt.Println(err)
 		fmt.Printf("The following parameters must be defined: %s\n", missing)
 		os.Exit(2)

--- a/notadash-mon/app.go
+++ b/notadash-mon/app.go
@@ -10,6 +10,12 @@ var VERSION = "0.1.0-beta"
 
 type boolmap map[string]bool
 
+var rsaRequired = []string{
+	"mesos-host",
+	"graphite-host",
+	"graphite-port",
+}
+
 var saRequired = []string{
 	"mesos-host",
 }
@@ -37,6 +43,16 @@ func buildApp() *cli.App {
 			Usage: "Show more output",
 		},
 		cli.StringFlag{
+			Name:   "graphite-host",
+			Usage:  "URL to use for Graphite metrics reporting.",
+			EnvVar: "NOTADASH_GRAPHITE_URL",
+		},
+		cli.IntFlag{
+			Name:   "graphite-port",
+			Usage:  "Port to use for Graphite metrics reporting.",
+			EnvVar: "NOTADASH_GRAPHITE_PORT",
+		},
+		cli.StringFlag{
 			Name:   "marathon-host",
 			Usage:  "URL to use for Marathon cluster discovery.",
 			EnvVar: "NOTADASH_MARATHON_URL",
@@ -59,6 +75,11 @@ func buildApp() *cli.App {
 	}
 
 	app.Commands = []cli.Command{
+		{
+			Name: "report-allocation",
+			Usage: "send currently allocated resources to graphite",
+			Action: reportSlaveAllocation,
+		},
 		{
 			Name:   "resources",
 			Usage:  "Show resource allocation per node across the cluster.",
@@ -83,6 +104,17 @@ func buildApp() *cli.App {
 	}
 
 	return app
+}
+
+func reportSlaveAllocation(ctx *cli.Context) {
+	if missing, err := validateContext(ctx, saRequired); err != nil {
+		fmt.Println(err)
+		fmt.Printf("The following parameters must be defined: %s\n", missing)
+		os.Exit(2)
+	}
+
+	exitStatus := runReportSlaveAllocation(ctx)
+	os.Exit(exitStatus)
 }
 
 func showAllocation(ctx *cli.Context) {

--- a/notadash-mon/graphite.go
+++ b/notadash-mon/graphite.go
@@ -2,12 +2,11 @@ package main
 
 import (
 	"fmt"
-	"strings"
+	lib "github.com/boldfield/notadash/lib"
 	"github.com/codegangsta/cli"
 	"github.com/marpaia/graphite-golang"
-	lib "github.com/boldfield/notadash/lib"
+	"strings"
 )
-
 
 func connectToGraphite(host string, port int) (g *graphite.Graphite, err error) {
 	if g, err = graphite.NewGraphite(host, port); err != nil {

--- a/notadash-mon/graphite.go
+++ b/notadash-mon/graphite.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"github.com/codegangsta/cli"
+	"github.com/marpaia/graphite-golang"
+	lib "github.com/boldfield/notadash/lib"
+)
+
+
+func connectToGraphite(host string, port int) (g *graphite.Graphite, err error) {
+	if g, err = graphite.NewGraphite(host, port); err != nil {
+		fmt.Println("An error occurred while trying to connect to the graphite server: (%s:%d)", host, port)
+		fmt.Println(err)
+	}
+	fmt.Printf("Loaded Graphite connection: %#v\n", g)
+	return
+}
+
+func sendToGraphite(g *graphite.Graphite, name string, path string, metric string) (err error) {
+	mpath := strings.Join([]string{path, name}, ".")
+	err = g.SimpleSend(mpath, metric)
+	if err != nil {
+		fmt.Println("Failed to send %v from %v to Graphite server", name, path)
+	}
+	return
+}
+
+func loadCluster(host string) (mesos *lib.Mesos) {
+	mesos = &lib.Mesos{
+		Host: host,
+	}
+	mesosClient := mesos.Client()
+	mesos.LoadCluster(mesosClient)
+
+	return
+}
+
+func runReportSlaveAllocation(ctx *cli.Context) int {
+	cluster := loadCluster(ctx.GlobalString("mesos-host"))
+	g, err := connectToGraphite(
+		ctx.GlobalString("graphite-host"),
+		ctx.GlobalInt("graphite-port"),
+	)
+	if err != nil {
+		fmt.Println(err)
+		return 1
+	}
+	defer g.Disconnect()
+
+	for _, s := range cluster.Cluster.Slaves {
+		ss := s.Stats
+		hostname := strings.Split(s.HostName, ".")[0]
+		m_path := strings.Join([]string{"mesos-stats", hostname}, ".")
+
+		sendToGraphite(g, "CpusPercent", m_path, fmt.Sprintf("%.2f", ss.CpusPercent))
+		sendToGraphite(g, "CpusUsed", m_path, fmt.Sprintf("%.2f", ss.CpusUsed))
+		sendToGraphite(g, "CpusTotal", m_path, fmt.Sprintf("%d", ss.CpusTotal))
+		sendToGraphite(g, "MemPercent", m_path, fmt.Sprintf("%.2f", ss.MemPercent))
+		sendToGraphite(g, "MemUsed", m_path, fmt.Sprintf("%d", ss.MemUsed))
+		sendToGraphite(g, "MemTotal", m_path, fmt.Sprintf("%d", ss.MemTotal))
+		sendToGraphite(g, "DiskPercent", m_path, fmt.Sprintf("%.2f", ss.DiskPercent))
+		sendToGraphite(g, "DiskUsed", m_path, fmt.Sprintf("%d", ss.DiskUsed))
+		sendToGraphite(g, "DiskTotal", m_path, fmt.Sprintf("%d", ss.DiskTotal))
+	}
+
+	return 0
+}

--- a/notadash-mon/slave.go
+++ b/notadash-mon/slave.go
@@ -98,7 +98,7 @@ func loadMesos(mesosHost string) (*lib.MesosSlave, error) {
 	}
 
 	host = bytes.Trim(host, " \n\t")
-	slave, err := mesos.LoadSlave(string(host), mesosClient)
+	slave, err := mesos.LoadSlaveState(string(host), mesosClient)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This lets you push mesos worker resource allocation data to an external graphite server. 

It also cleans up the prior feature to actually print percentages (1-100) instead of decimals.