### PR TITLE
Michael/alert docker fail

### DIFF
--- a/notadash-mon/allocation.go
+++ b/notadash-mon/allocation.go
@@ -17,7 +17,7 @@ func runShowAllocation(ctx *cli.Context) int {
 	mesos.LoadCluster(mesosClient)
 
 	output := make([]string, 1)
-	output[0] = "Hostnamme | Cpu % | Cpu Ratio | Mem % | Mem Ratio | Disk % | Disk Ratio"
+	output[0] = "Hostname | Cpu % | Cpu Ratio | Mem % | Mem Ratio | Disk % | Disk Ratio"
 
 	for _, s := range mesos.Cluster.Slaves {
 		ss := s.Stats

--- a/notadash-mon/app.go
+++ b/notadash-mon/app.go
@@ -24,6 +24,10 @@ var csRequired = []string{
 	"mesos-host",
 }
 
+var ffRequired = []string{
+	"marathon-host",
+}
+
 func buildApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "notadash-mon"
@@ -80,6 +84,11 @@ func buildApp() *cli.App {
 			Usage:  "Verify all tasks registered for mesos slave are running as expected. Must be run on target mesos slave.",
 			Action: checkSlave,
 		},
+		{
+			Name: "failures",
+			Usage: "Show any marathon tasks that are failing.",
+			Action: findFailures,
+		},
 	}
 
 	return app
@@ -115,5 +124,15 @@ func checkSlave(ctx *cli.Context) {
 	}
 
 	exitStatus := runCheckSlave(ctx)
+	os.Exit(exitStatus)
+}
+
+func findFailures(ctx *cli.Context) {
+	if missing, err := validateContext(ctx, ffRequired); err != nil {
+		fmt.Println(err)
+		fmt.Printf("The following parameters must be defined: %s\n", missing)
+		os.Exit(1)
+	}
+	exitStatus := runFindFailures(ctx)
 	os.Exit(exitStatus)
 }

--- a/notadash-mon/failures.go
+++ b/notadash-mon/failures.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	lib "github.com/boldfield/notadash/lib"
+	"github.com/codegangsta/cli"
+	"github.com/ryanuber/columnize"
+)
+
+func runFindFailures(ctx *cli.Context) int {
+	fmt.Println("Checking for tasks that have 0 running instances...")
+
+	marathon, err := loadMarathon(ctx.GlobalString("marathon-host"))
+	if err != nil {
+		fmt.Println(err)
+		return 1
+	}
+
+	output := make([]string, 1)
+	output[0] = "Application | Instances | Running Tasks"
+	discrepancy := false
+	for _, a := range marathon.Apps {
+		if a.Instances > 0 && a.TasksRunning == 0 {
+			discrepancy = true
+			line := fmt.Sprintf(
+				"%s | %d | %d",
+				a.ID,
+				a.Instances,
+				a.TasksRunning,
+			)
+			output = append(output, line)
+		}
+	}
+	if discrepancy {
+		fmt.Println(lib.PrintYellow("Failing Marathon task found!"))
+		result := columnize.SimpleFormat(output)
+		fmt.Println(result)
+		return 2
+	}
+	return 0
+}


### PR DESCRIPTION
We should talk about this approach as I'm not sure I'm totally happy with it. 

The basic idea would be to check this and alert if we received a high percentage of failures within a short period of time. It will flap with failing docker containers, not *always* return a non-zero exit code.

Another idea would be to check the mesos logs for a high number of failing docker containers with the same ID. I'm working on that now, let's talk tomorrow about the best approach.