### PR TITLE
Add failed-tasks option to notadash-mon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 BUILD_ROOT = ./bin
 
+test:
+	go test ./... -v -cover 
+
 build:
 	go build -o $(BUILD_ROOT)/notadash \
 		-ldflags "-X main.VERSION $(shell cat notadash/VERSION)" \
@@ -24,3 +27,6 @@ build-deps:
 	go get github.com/gambol99/go-marathon
 	go get github.com/boldfield/go-mesos
 	go get golang.org/x/crypto/ssh/terminal
+
+clean:
+	rm -rf bin

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,3 @@ build-deps:
 	go get github.com/gambol99/go-marathon
 	go get github.com/boldfield/go-mesos
 	go get golang.org/x/crypto/ssh/terminal
-
-clean:
-	rm -rf bin

--- a/lib/mesos.go
+++ b/lib/mesos.go
@@ -29,12 +29,10 @@ func (m *Mesos) Client() *mesos.Client {
 	return m._client
 }
 
+// Loads the entire cluster, including information about slaves
 func (m *Mesos) LoadCluster(c *mesos.Client) error {
-	if cluster, err := mesos.DiscoverCluster(c); err != nil {
-		log.Println(err)
+	if err := m.LoadClusterInfo(c); err != nil {
 		return err
-	} else {
-		m.Cluster = cluster
 	}
 
 	if err := m.Cluster.LoadSlaveStates(c); err != nil {
@@ -45,6 +43,18 @@ func (m *Mesos) LoadCluster(c *mesos.Client) error {
 	if err := m.Cluster.LoadSlaveStats(c); err != nil {
 		log.Printf("An error was encountered loading slave states: %s", err)
 		return err
+	}
+	return nil
+}
+
+// Loads information about the cluster from the master, does not check slaves
+// TODO: (michaelb) what should this be called?
+func (m *Mesos) LoadClusterInfo(c *mesos.Client) error {
+	if cluster, err := mesos.DiscoverCluster(c); err != nil {
+		log.Println(err)
+		return err
+	} else {
+		m.Cluster = cluster
 	}
 	return nil
 }

--- a/lib/mesos.go
+++ b/lib/mesos.go
@@ -48,7 +48,6 @@ func (m *Mesos) LoadCluster(c *mesos.Client) error {
 }
 
 // Loads information about the cluster from the master, does not check slaves
-// TODO: (michaelb) what should this be called?
 func (m *Mesos) LoadClusterInfo(c *mesos.Client) error {
 	if cluster, err := mesos.DiscoverCluster(c); err != nil {
 		log.Println(err)

--- a/notadash-mon/allocation.go
+++ b/notadash-mon/allocation.go
@@ -22,7 +22,7 @@ func runShowAllocation(ctx *cli.Context) int {
 
 func printAllocations(mesos *lib.Mesos) int {
 	output := make([]string, 1)
-	output[0] = "Hostnamme | Cpu % | Cpu Ratio | Mem % | Mem Ratio | Disk % | Disk Ratio"
+	output[0] = "Hostname | Cpu % | Cpu Ratio | Mem % | Mem Ratio | Disk % | Disk Ratio"
 
 	for _, s := range mesos.Cluster.Slaves {
 		ss := s.Stats

--- a/notadash-mon/app.go
+++ b/notadash-mon/app.go
@@ -29,6 +29,10 @@ var csRequired = []string{
 	"mesos-host",
 }
 
+var fftRequired = []string{
+	"mesos-host",
+}
+
 func buildApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "notadash-mon"
@@ -105,6 +109,21 @@ func buildApp() *cli.App {
 			Usage:  "Verify all tasks registered for mesos slave are running as expected. Must be run on target mesos slave.",
 			Action: checkSlave,
 		},
+		{
+			Name: "failed-tasks",
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  "time-window",
+					Usage: "Time window to look for failed tasks (in minutes)",
+				},
+				cli.IntFlag{
+					Name:  "failure-limit",
+					Usage: "Number of times the task must have failed before triggering an error",
+				},
+			},
+			Usage:  "Show any marathon tasks that are failing.",
+			Action: findFailedTasks,
+		},
 	}
 
 	return app
@@ -151,5 +170,15 @@ func checkSlave(ctx *cli.Context) {
 	}
 
 	exitStatus := runCheckSlave(ctx)
+	os.Exit(exitStatus)
+}
+
+func findFailedTasks(ctx *cli.Context) {
+	if missing, err := validateContext(ctx, fftRequired); err != nil {
+		fmt.Println(err)
+		fmt.Printf("The following parameters must be defined: %s\n", missing)
+		os.Exit(1)
+	}
+	exitStatus := runFailedTasks(ctx)
 	os.Exit(exitStatus)
 }

--- a/notadash-mon/failed_tasks.go
+++ b/notadash-mon/failed_tasks.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	lib "github.com/boldfield/notadash/lib"
+	"github.com/codegangsta/cli"
+	"github.com/ryanuber/columnize"
+	"time"
+)
+
+func runFailedTasks(ctx *cli.Context) int {
+	fmt.Println("Discovering completed mesos tasks")
+
+	mesos := &lib.Mesos{
+		Host: ctx.GlobalString("mesos-host"),
+	}
+	mesosClient := mesos.Client()
+	if err := mesos.LoadClusterInfo(mesosClient); err != nil {
+		fmt.Println(err)
+		return 1
+	}
+	frameworks := mesos.Framework("marathon")
+
+	timeWindow := ctx.Int("time-window")
+	failureLimit := ctx.Int("failure-limit")
+
+	// map of all containers to number of failures in the last 30 min
+	failingMap := make(map[string]int)
+	now := float64(time.Now().Unix())
+	if len(frameworks) > 0 {
+		for _, f := range frameworks {
+			for _, t := range f.CompletedTasks {
+				failure := false
+				for _, s := range t.Statuses {
+					if s.State == "TASK_FAILED" {
+						age := now - s.Timestamp
+						failure = age < float64(60*timeWindow) // minutes
+					}
+				}
+				if failure {
+					failingMap[t.Name]++
+				}
+			}
+		}
+	}
+
+	if len(failingMap) == 0 {
+		fmt.Println(lib.PrintGreen(fmt.Sprintf("No failures found in the last %d minutes", timeWindow)))
+		return 0
+	}
+
+	returnError := false
+	output := make([]string, 1)
+	output[0] = "Application | Num Failures"
+	for app, numFailures := range failingMap {
+		line := fmt.Sprintf("%s | %d", app, numFailures)
+		output = append(output, line)
+		if numFailures > failureLimit {
+			returnError = true
+		}
+	}
+
+	result := columnize.SimpleFormat(output)
+	fmt.Println(result)
+
+	if returnError {
+		fmt.Println(lib.PrintRed(fmt.Sprintf("Found errors above the failure limit of %d", failureLimit)))
+		return 2
+	}
+
+	fmt.Println(lib.PrintYellow(fmt.Sprintf("Errors found, but not above the failure limit of %d", failureLimit)))
+	return 0
+}


### PR DESCRIPTION
This adds a new command to notadash-mon. By running the `failed-tasks` command, you can check for failing tasks that have occurred within a specific `time-window` and alert if that number reaches a `failure-limit`.

Example:
```
$ bin/notadash-mon --mesos-host http://mesos.aws-us-west-2-staging.socrata.net failed-tasks --time-window 30 --failure-limit 10
```

TODO: update the `go-mesos` references once boldfield/go-mesos#2 is merged. 